### PR TITLE
Initial Implementation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/override*.yaml

--- a/README.md
+++ b/README.md
@@ -1,0 +1,23 @@
+# Kubernetes NGINX Ingress
+
+A helm deployment package for a simple NGINX ingress service via an AWS ELB.
+
+## Usage
+
+First create an `override.yaml` file which contains the AWS ARN for the SSL certificate you wish the ELB to use.
+
+```
+# override.yaml
+
+service:
+  ssl:
+    aws_certificate_arn: "arn:aws:example-arn"
+```
+
+Next check the `helm/k8s-nginx-ingress/app-configs` directory for a suitable configuration for your requirements, or create a new one.
+
+To deploy to the configured kubernetes cluster, run:
+
+```
+helm upgrade -i nginx-ingress ./helm/k8s-nginx-ingress -f ./helm/k8s-nginx-ingress/app-configs/nginx-ingress_pac.yaml -f override.yaml
+```

--- a/helm/k8s-nginx-ingress/Chart.yaml
+++ b/helm/k8s-nginx-ingress/Chart.yaml
@@ -1,0 +1,4 @@
+apiVersion: v1
+description: Kubernetes NGINX Ingress Configured for AWS
+name: nginx-ingress
+version: 0.0.0

--- a/helm/k8s-nginx-ingress/app-configs/nginx-ingress_pac.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/nginx-ingress_pac.yaml
@@ -1,0 +1,2 @@
+service:
+  name: nginx-ingress

--- a/helm/k8s-nginx-ingress/templates/nginx-config.yaml
+++ b/helm/k8s-nginx-ingress/templates/nginx-config.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  proxy-set-headers: {{ .Values.service.namespace }}/{{ .Values.service.name }}-custom-headers
+kind: ConfigMap
+metadata:
+  name: {{ .Values.service.name }}-config
+  namespace: {{ .Values.service.namespace }}

--- a/helm/k8s-nginx-ingress/templates/nginx-custom-headers.yaml
+++ b/helm/k8s-nginx-ingress/templates/nginx-custom-headers.yaml
@@ -1,0 +1,7 @@
+apiVersion: v1
+data:
+  X-Original-Request-URL: "$scheme://$host$request_uri"
+kind: ConfigMap
+metadata:
+  name: {{ .Values.service.name }}-custom-headers
+  namespace: {{ .Values.service.namespace }}

--- a/helm/k8s-nginx-ingress/templates/nginx-ingress-controller.yaml
+++ b/helm/k8s-nginx-ingress/templates/nginx-ingress-controller.yaml
@@ -1,0 +1,66 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: "{{ .Values.service.name }}"
+  annotations:
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{{ .Values.service.ssl.aws_certificate_arn }}"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
+    service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
+spec:
+  type: LoadBalancer
+  ports:
+    # Removed the plaintext port - but we could reinstate with an https redirect in future.
+    # - port: 80
+    #  name: http
+    - port: 443
+      name: https
+      targetPort: 80
+      protocol: TCP
+  selector:
+    k8s-app: "{{ .Values.service.name }}-load-balancer"
+---
+apiVersion: extensions/v1beta1
+kind: Deployment
+metadata:
+  name: {{ .Values.service.name }}-controller
+spec:
+  replicas: {{ .Values.replicaCount }}
+  revisionHistoryLimit: 3
+  template:
+    metadata:
+      labels:
+        k8s-app: "{{ .Values.service.name }}-load-balancer"
+    spec:
+      terminationGracePeriodSeconds: 60
+      containers:
+        - name: {{ .Values.service.name }}-controller
+          image: {{ .Values.image.repository }}:{{ .Values.image.version }}
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 18080
+              scheme: HTTP
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 18080
+              scheme: HTTP
+            initialDelaySeconds: 10
+            timeoutSeconds: 5
+          args:
+            - /nginx-ingress-controller
+            - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+            - --configmap=$(POD_NAMESPACE)/{{ .Values.service.name }}-config
+          env:
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
+            - name: POD_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
+          ports:
+            - containerPort: 80
+            - containerPort: 443

--- a/helm/k8s-nginx-ingress/values.yaml
+++ b/helm/k8s-nginx-ingress/values.yaml
@@ -1,0 +1,12 @@
+service:
+  name: "" # The name of the service, should be defined in the specific app-configs folder
+  namespace: default
+  ssl:
+    aws_certificate_arn: "" # The AWS ARN for the ft.com Certificate - needs to be added at helm runtime via the CLI
+
+image:
+  repository: gcr.io/google_containers/nginx-ingress-controller
+  version: 0.9.0-beta.11
+  pullPolicy: Always
+
+replicaCount: 2


### PR DESCRIPTION
This will setup an NGINX ingress controller, with an ELB load balancer configured (currently) to only serve requests via https. 

It will also setup a ConfigMap to configure any NGINX settings, plus an extra ConfigMap which contains the custom http header `X-Original-Request-URL`.