### PR TITLE
Expose 2 controllers

### DIFF
--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery.yaml
@@ -1,0 +1,13 @@
+service:
+  name: internal-k8s-nginx-ingress
+
+ingress_class: nginx-internal
+
+
+elb:
+  enabled: "true"
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:070529446553:certificate/53071112-759c-4875-97e2-c62425df1381"
+  tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=d"
+
+  register_dns: "false"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery.yaml
@@ -3,11 +3,9 @@ service:
 
 ingress_class: nginx-internal
 
-
 elb:
   enabled: "true"
   ssl:
     aws_certificate_arn: "arn:aws:acm:eu-west-1:070529446553:certificate/53071112-759c-4875-97e2-c62425df1381"
   tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=d"
-
   register_dns: "false"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery.yaml
@@ -1,6 +1,5 @@
 service:
   name: internal-k8s-nginx-ingress
-
 ingress_class: nginx-internal
 
 elb:
@@ -9,3 +8,5 @@ elb:
     aws_certificate_arn: "arn:aws:acm:eu-west-1:070529446553:certificate/53071112-759c-4875-97e2-c62425df1381"
   tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=d"
   register_dns: "false"
+  internal: "true"
+  security_groups: "sg-53531d2b"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery_prod_eu.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery_prod_eu.yaml
@@ -1,0 +1,12 @@
+service:
+  name: internal-k8s-nginx-ingress
+ingress_class: nginx-internal
+
+elb:
+  enabled: "true"
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
+  tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=p"
+  register_dns: "false"
+  internal: "true"
+  security_groups: "sg-16663e6e"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery_prod_us.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery_prod_us.yaml
@@ -1,0 +1,12 @@
+service:
+  name: internal-k8s-nginx-ingress
+ingress_class: nginx-internal
+
+elb:
+  enabled: "true"
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
+  tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=p"
+  register_dns: "false"
+  internal: "true"
+  security_groups: "sg-71f03702"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery_staging_eu.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery_staging_eu.yaml
@@ -1,0 +1,12 @@
+service:
+  name: internal-k8s-nginx-ingress
+ingress_class: nginx-internal
+
+elb:
+  enabled: "true"
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
+  tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=t"
+  register_dns: "false"
+  internal: "true"
+  security_groups: "sg-16663e6e"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery_staging_us.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_delivery_staging_us.yaml
@@ -1,0 +1,12 @@
+service:
+  name: internal-k8s-nginx-ingress
+ingress_class: nginx-internal
+
+elb:
+  enabled: "true"
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
+  tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=t"
+  register_dns: "false"
+  internal: "true"
+  security_groups: "sg-71f03702"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_pac_prodpac_eu.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_pac_prodpac_eu.yaml
@@ -1,0 +1,12 @@
+service:
+  name: internal-k8s-nginx-ingress
+ingress_class: nginx-internal
+
+elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
+  tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=p"
+  enabled: "true"
+  register_dns: "false"
+  internal: "true"
+  security_groups: "sg-16663e6e"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_pac_prodpac_us.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_pac_prodpac_us.yaml
@@ -1,0 +1,12 @@
+service:
+  name: internal-k8s-nginx-ingress
+ingress_class: nginx-internal
+
+elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
+  tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=p"
+  enabled: "true"
+  register_dns: "false"
+  internal: "true"
+  security_groups: "sg-71f03702"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_pac_stagingpac_eu.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_pac_stagingpac_eu.yaml
@@ -1,0 +1,12 @@
+service:
+  name: internal-k8s-nginx-ingress
+ingress_class: nginx-internal
+
+elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
+  tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=t"
+  enabled: "true"
+  register_dns: "false"
+  internal: "true"
+  security_groups: "sg-16663e6e"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_pac_stagingpac_us.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_pac_stagingpac_us.yaml
@@ -1,0 +1,12 @@
+service:
+  name: internal-k8s-nginx-ingress
+ingress_class: nginx-internal
+
+elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
+  tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=t"
+  enabled: "true"
+  register_dns: "false"
+  internal: "true"
+  security_groups: "sg-71f03702"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_publishing.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_publishing.yaml
@@ -1,6 +1,12 @@
 service:
-  name: k8s-nginx-ingress
+  name: internal-k8s-nginx-ingress
+
+ingress_class: nginx-internal
+
 
 elb:
-  enabled: "false"
+  enabled: "true"
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:070529446553:certificate/53071112-759c-4875-97e2-c62425df1381"
+  tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=d"
   register_dns: "false"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_publishing.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_publishing.yaml
@@ -1,9 +1,6 @@
 service:
   name: k8s-nginx-ingress
 
-replicaCount: 0
-
 elb:
   enabled: "false"
   register_dns: "false"
-

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_publishing.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_publishing.yaml
@@ -1,8 +1,6 @@
 service:
   name: internal-k8s-nginx-ingress
-
 ingress_class: nginx-internal
-
 
 elb:
   enabled: "true"
@@ -10,3 +8,5 @@ elb:
     aws_certificate_arn: "arn:aws:acm:eu-west-1:070529446553:certificate/53071112-759c-4875-97e2-c62425df1381"
   tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=d"
   register_dns: "false"
+  internal: "true"
+  security_groups: "sg-53531d2b"

--- a/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_delivery.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_delivery.yaml
@@ -1,9 +1,0 @@
-service:
-  name: k8s-nginx-ingress
-
-replicaCount: 0
-
-elb:
-  enabled: "false"
-  register_dns: "false"
-

--- a/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_gcpac_eu.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_gcpac_eu.yaml
@@ -1,10 +1,9 @@
 service:
   name: k8s-nginx-ingress
-  ssl:
-    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
 
 elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
   tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=t"
-
-nginx_lb:
   enabled: "true"
+  register_dns: "true"

--- a/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_prodpac_eu.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_prodpac_eu.yaml
@@ -1,10 +1,9 @@
 service:
   name: k8s-nginx-ingress
-  ssl:
-    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
 
 elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
   tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=p"
-
-nginx_lb:
   enabled: "true"
+  register_dns: "true"

--- a/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_prodpac_us.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_prodpac_us.yaml
@@ -1,10 +1,9 @@
 service:
   name: k8s-nginx-ingress
-  ssl:
-    aws_certificate_arn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
 
 elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
   tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=p"
-
-nginx_lb:
   enabled: "true"
+  register_dns: "true"

--- a/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_stagingpac_eu.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_stagingpac_eu.yaml
@@ -1,10 +1,9 @@
 service:
   name: k8s-nginx-ingress
-  ssl:
-    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
 
 elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:eu-west-1:469211898354:certificate/4e431fdf-0a66-436a-a998-37dd61307447"
   tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=t"
-
-nginx_lb:
   enabled: "true"
+  register_dns: "true"

--- a/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_stagingpac_us.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_pac_stagingpac_us.yaml
@@ -1,10 +1,9 @@
 service:
   name: k8s-nginx-ingress
-  ssl:
-    aws_certificate_arn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
 
 elb:
+  ssl:
+    aws_certificate_arn: "arn:aws:acm:us-east-1:469211898354:certificate/bde07970-60f9-4683-a367-fdf05b276b0a"
   tags: "systemCode=pac,teamDL=universal.publishing.platform@ft.com,environment=t"
-
-nginx_lb:
   enabled: "true"
+  register_dns: "true"

--- a/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_publishing.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_publishing.yaml
@@ -1,5 +1,8 @@
 service:
   name: k8s-nginx-ingress
 
-nginx_lb:
+replicaCount: 0
+
+elb:
   enabled: "false"
+  register_dns: "false"

--- a/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_publishing.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/k8s-nginx-ingress_publishing.yaml
@@ -1,8 +1,0 @@
-service:
-  name: k8s-nginx-ingress
-
-replicaCount: 0
-
-elb:
-  enabled: "false"
-  register_dns: "false"

--- a/helm/k8s-nginx-ingress/templates/default-http-backend.yaml
+++ b/helm/k8s-nginx-ingress/templates/default-http-backend.yaml
@@ -1,16 +1,16 @@
 apiVersion: extensions/v1beta1
 kind: Deployment
 metadata:
-  name: default-http-backend
+  name: {{ .Values.service.name }}-default-http-backend
   labels:
-    k8s-app: default-http-backend
+    k8s-app: {{ .Values.service.name }}-default-http-backend
   namespace: {{ .Values.service.namespace }}
 spec:
   replicas: 1
   template:
     metadata:
       labels:
-        k8s-app: default-http-backend
+        k8s-app: {{ .Values.service.name }}-default-http-backend
     spec:
       terminationGracePeriodSeconds: 60
       containers:
@@ -36,13 +36,13 @@ spec:
 apiVersion: v1
 kind: Service
 metadata:
-  name: default-http-backend
+  name: {{ .Values.service.name }}-default-http-backend
   namespace: {{ .Values.service.namespace }}
   labels:
-    k8s-app: default-http-backend
+    k8s-app: {{ .Values.service.name }}-default-http-backend
 spec:
   ports:
   - port: 80
     targetPort: 8080
   selector:
-    k8s-app: default-http-backend
+    k8s-app: {{ .Values.service.name }}-default-http-backend

--- a/helm/k8s-nginx-ingress/templates/elb-dns-registrator.yaml
+++ b/helm/k8s-nginx-ingress/templates/elb-dns-registrator.yaml
@@ -1,8 +1,8 @@
-{{- if eq .Values.nginx_lb.enabled "true"}}
+{{- if eq .Values.elb.register_dns "true"}}
 apiVersion: batch/v1
 kind: Job
 metadata:
-  name: "{{ .Values.service.name }}-elb-registrator-job-{{ .Release.Revision}}"
+  name: "{{ .Values.service.name }}-elb-reg-job-{{ .Release.Revision}}-{ randAlpha 5 | lower}}"
   # This is what defines this resource as a hook. Without this line, the
   # job is considered part of the release.
   annotations:

--- a/helm/k8s-nginx-ingress/templates/nginx-ingress-controller.yaml
+++ b/helm/k8s-nginx-ingress/templates/nginx-ingress-controller.yaml
@@ -29,7 +29,7 @@ spec:
             timeoutSeconds: 5
           args:
             - /nginx-ingress-controller
-            - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
+            - --default-backend-service=$(POD_NAMESPACE)/{{ .Values.service.name }}-default-http-backend
             - --configmap=$(POD_NAMESPACE)/{{ .Values.service.name }}-config
             - '--ingress-class={{.Values.ingress_class}}'
           env:

--- a/helm/k8s-nginx-ingress/templates/nginx-ingress-controller.yaml
+++ b/helm/k8s-nginx-ingress/templates/nginx-ingress-controller.yaml
@@ -31,6 +31,7 @@ spec:
             - /nginx-ingress-controller
             - --default-backend-service=$(POD_NAMESPACE)/default-http-backend
             - --configmap=$(POD_NAMESPACE)/{{ .Values.service.name }}-config
+            - '--ingress-class={{.Values.ingress_class}}'
           env:
             - name: POD_NAME
               valueFrom:

--- a/helm/k8s-nginx-ingress/templates/nginx-ingress-lb.yaml
+++ b/helm/k8s-nginx-ingress/templates/nginx-ingress-lb.yaml
@@ -1,10 +1,10 @@
-{{- if eq .Values.nginx_lb.enabled "true"}}
+{{- if eq .Values.elb.enabled "true"}}
 apiVersion: v1
 kind: Service
 metadata:
   name: "{{ .Values.service.name }}"
   annotations:
-    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{{ .Values.service.ssl.aws_certificate_arn }}"
+    service.beta.kubernetes.io/aws-load-balancer-ssl-cert: "{{ .Values.elb.ssl.aws_certificate_arn }}"
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "{{ .Values.elb.tags }}"

--- a/helm/k8s-nginx-ingress/templates/nginx-ingress-lb.yaml
+++ b/helm/k8s-nginx-ingress/templates/nginx-ingress-lb.yaml
@@ -8,6 +8,12 @@ metadata:
     service.beta.kubernetes.io/aws-load-balancer-ssl-ports: "443"
     service.beta.kubernetes.io/aws-load-balancer-backend-protocol: http
     service.beta.kubernetes.io/aws-load-balancer-additional-resource-tags: "{{ .Values.elb.tags }}"
+    {{- if ne .Values.elb.security_groups ""}}
+    service.beta.kubernetes.io/aws-load-balancer-extra-security-groups: "{{ .Values.elb.security_groups }}"
+    {{- end }}
+    {{- if eq .Values.elb.internal "true"}}
+    service.beta.kubernetes.io/aws-load-balancer-internal: 0.0.0.0/0
+    {{- end }}
 spec:
   type: LoadBalancer
   ports:

--- a/helm/k8s-nginx-ingress/values.yaml
+++ b/helm/k8s-nginx-ingress/values.yaml
@@ -1,8 +1,8 @@
 service:
   name: "" # The name of the service, should be defined in the specific app-configs folder
   namespace: default
-  ssl:
-    aws_certificate_arn: "" # The AWS ARN for the ft.com Certificate - needs to be added at helm runtime via the CLI
+
+ingress_class: nginx
 
 image:
   repository: gcr.io/google_containers/nginx-ingress-controller
@@ -11,5 +11,19 @@ image:
 
 elbRegistrator:
   image: "coco/coco-elb-dns-registrator:5.0.0"
+
+elb:
+  # Flag for creating a load balancer for the nginx controller
+  enabled: "true"
+
+  ssl:
+    # The AWS ARN for the ft.com Certificate - needs to be added at helm runtime via the CLI
+    aws_certificate_arn: ""
+
+  # Additional tags to put on ELB
+  tags: ""
+
+  # Flag indicating if the DNS subdomain of the environment should be registered as a CNAME for the Nginx ELB
+  register_dns: "false"
 
 replicaCount: 2

--- a/helm/k8s-nginx-ingress/values.yaml
+++ b/helm/k8s-nginx-ingress/values.yaml
@@ -20,6 +20,12 @@ elb:
     # The AWS ARN for the ft.com Certificate - needs to be added at helm runtime via the CLI
     aws_certificate_arn: ""
 
+  # Additional security groups to attach to the ELB
+  security_groups: ""
+
+  # Flag indicating whether the ELB is internal or public to the internet.
+  internal: "false"
+
   # Additional tags to put on ELB
   tags: ""
 


### PR DESCRIPTION
Exposing 2 types of controllers:
- one that is attached to a public ELB - this is mainly for PAC
- one that is attached to an internal ELB - this is supposed to be used for exposing internal services inside FT (DEX, prometheus etc)

I tested already the internal one in dev for prometheus.