### PR TITLE
Add dns_zone var to the elb-dns-registrator job

### DIFF
--- a/helm/k8s-nginx-ingress/templates/elb-dns-registrator.yaml
+++ b/helm/k8s-nginx-ingress/templates/elb-dns-registrator.yaml
@@ -27,6 +27,11 @@ spec:
             configMapKeyRef:
               name: global-config
               key: environment
+        - name: DomainZone
+          valueFrom:
+            configMapKeyRef:
+              name: global-config
+              key: dns_zone
         - name: KONSTRUCTOR_API_KEY
           valueFrom:
             secretKeyRef:

--- a/helm/k8s-nginx-ingress/values.yaml
+++ b/helm/k8s-nginx-ingress/values.yaml
@@ -10,7 +10,7 @@ image:
   pullPolicy: Always
 
 elbRegistrator:
-  image: "coco/coco-elb-dns-registrator:5.0.1"
+  image: "coco/coco-elb-dns-registrator:5.1.0"
 
 elb:
   # Flag for creating a load balancer for the nginx controller


### PR DESCRIPTION
As part of the DNS migration we need to be able to configure the DNS zone provided to the Konstructor API. With this change upgrade the coco/coco-elb-dns-registrator version to 5.1.0. This version support the DomainZone parameter. Also, we add the DomainZone value to be taken from the global-config configmap dns_zone key.

This change depends on Financial-Times/upp-global-configs#89 and Financial-Times/pac-global-config#21