### PR TITLE
Update eks_delivery_dev app-configs

### DIFF
--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_eks_delivery_dev.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_eks_delivery_dev.yaml
@@ -11,4 +11,3 @@ elb:
   tags: "systemCode=upp,teamDL=universal.publishing.platform@ft.com,environment=d"
   register_dns: "false"
   internal: "true"
-  security_groups: "sg-16663e6e"

--- a/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_eks_delivery_test.yaml
+++ b/helm/k8s-nginx-ingress/app-configs/internal-k8s-nginx-ingress_eks_delivery_test.yaml
@@ -11,4 +11,3 @@ elb:
   enabled: "true"
   register_dns: "false"
   internal: "true"
-  security_groups: "sg-16663e6e"


### PR DESCRIPTION
Remove the `sg-16663e6e` SG. It is not required and does not exist in the test account.