### PR TITLE
Automatically recreating RUNBOOK.md without relationships [Skip CI]

### DIFF
--- a/runbooks/k8s-nginx-ingress-runbook.md
+++ b/runbooks/k8s-nginx-ingress-runbook.md
@@ -1,10 +1,18 @@
+<!--
+    Written in the format prescribed by https://github.com/Financial-Times/runbook.md.
+    Any future edits should abide by this format.
+-->
 # UPP Kubernetes NGINX Ingress
 
 A helm deployment package for a simple NGINX ingress service via an AWS ELB.
 
+## Code
+
+k8s-nginx-ingress
+
 ## Primary URL
 
-<https://github.com/Financial-Times/k8s-nginx-ingress>
+https://github.com/Financial-Times/k8s-nginx-ingress
 
 ## Service Tier
 
@@ -13,23 +21,6 @@ Platinum
 ## Lifecycle Stage
 
 Production
-
-## Delivered By
-
-content
-
-## Supported By
-
-content
-
-## Known About By
-
-- donislav.belev
-- mihail.mihaylov
-- boyko.boykov
-- dimitar.terziev
-- miroslav.gatsanoga
-- kalin.arsov
 
 ## Host Platform
 
@@ -47,6 +38,20 @@ No
 ## Contains Sensitive Data
 
 No
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Download Personal Data
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
+
+<!-- Placeholder - remove HTML comment markers to activate
+## Can Contact Individuals
+Choose Yes or No
+
+...or delete this placeholder if not applicable to this system
+-->
 
 ## Failover Architecture Type
 
@@ -68,6 +73,14 @@ The service is deployed in all (PAC, Publish and Delivery) clusters. The failove
 
 None
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Data Recovery Details
+Enter descriptive text satisfying the following:
+The actions required to restore the data for this system. Either provide a set of numbered steps or a link to a detailed process that operations can follow.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Release Process Type
 
 PartiallyAutomated
@@ -80,6 +93,14 @@ Manual
 
 The release is triggered by making a Github release which is then picked up by a Jenkins multibranch pipeline. The Jenkins pipeline should be manually started in order for it to deploy the helm package to the Kubernetes clusters.
 
+<!-- Placeholder - remove HTML comment markers to activate
+## Heroku Pipeline Name
+Enter descriptive text satisfying the following:
+This is the name of the Heroku pipeline for this system. If you don't have a pipeline, this is the name of the app in Heroku. A pipeline is a group of Heroku apps that share the same codebase where each app in a pipeline represents the different stages in a continuous delivery workflow, i.e. staging, production.
+
+...or delete this placeholder if not applicable to this system
+-->
+
 ## Key Management Process Type
 
 None
@@ -90,12 +111,12 @@ There is no key rotation procedure for this system.
 
 ## Monitoring
 
-- https://pac-prod-eu.upp.ft.com/__health
-- https://pac-prod-us.upp.ft.com/__health
-- https://upp-prod-publish-eu.upp.ft.com/__health
-- https://upp-prod-publish-us.upp.ft.com/__health
-- https://upp-prod-delivery-us.upp.ft.com/__health
-- https://upp-prod-delivery-eu.upp.ft.com/__health
+*   <https://pac-prod-eu.upp.ft.com/__health>
+*   <https://pac-prod-us.upp.ft.com/__health>
+*   <https://upp-prod-publish-eu.upp.ft.com/__health>
+*   <https://upp-prod-publish-us.upp.ft.com/__health>
+*   <https://upp-prod-delivery-us.upp.ft.com/__health>
+*   <https://upp-prod-delivery-eu.upp.ft.com/__health>
 
 ## First Line Troubleshooting
 


### PR DESCRIPTION

## What
 - The [RUNBOOK.md](https://github.com/Financial-Times/k8s-nginx-ingress/blob/runbook-no-relationships-2021-03-19/runbooks/k8s-nginx-ingress-runbook.md) file has been automatically regenerated from the Biz Ops data for the **k8s-nginx-ingress** system.
 - All the relationships/dependencies have been excluded from RUNBOOK.md but are still in the **k8s-nginx-ingress** system in [Biz Ops](https://biz-ops.in.ft.com/System/k8s-nginx-ingress).
 - Please continue to manage those relationships/dependencies manually or via the Biz Ops API.

## Why
 - Support for relationships/dependencies within RUNBOOK.md is being removed to avoid the side effects [identified in this proposal](https://docs.google.com/document/d/1njFceyb49TeaIR53Y9r62CenTzdey1fyeJkUvxd9SQQ)
 - This is a prerequisite to the improved ownership/support model [defined in this proposal](https://docs.google.com/document/d/1vTRe7S5dUqIMAoWyqD2pMEkg_5998NCEeFwsxT_k9pw).

## Next Steps
 - Please check and merge this PR.
 - You should only see the removal of the **Delivered By**, **Supported By**, **Technical Owner**, **Known About By**, **Stakeholders**, **Dependencies** and **Healthcheck** sections. Please contact [#reliability-eng](https://financialtimes.slack.com/archives/C07B3043U) if there are other differences as your current runbook.md file may be inconsistent with Biz Ops.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are unlocking all the relationships/dependencies to re-enable manual/API updates.
 - [Reliability Engineering](https://financialtimes.slack.com/archives/C07B3043U) are adjusting the rules to allow these simpler RUNBOOK.md files to pass validation.
